### PR TITLE
Fixed drag error

### DIFF
--- a/04-etch-a-sketch/script.js
+++ b/04-etch-a-sketch/script.js
@@ -68,7 +68,7 @@ const createGrid = async () => {
 
 // Add event listener to the item
 const attachItemListeners = (element) => {
-    element.addEventListener('mousedown', (e) => { mouseDown = true });
+    element.addEventListener('mousedown', (e) => { mouseDown = true; e.preventDefault()},);
     element.addEventListener('mouseup', (e) => { mouseDown = false });
     element.addEventListener('mouseover', () => {
         if(mouseDown || !drawMode) {


### PR DESCRIPTION
Fixed drag error in draw mode by adding `e.preventDefault()` to `mousedown` event.